### PR TITLE
Fix a typo in the mardown

### DIFF
--- a/developer/event_guide.html
+++ b/developer/event_guide.html
@@ -89,7 +89,7 @@
 
 <p>Meta-data selection requires you to think. To create an event type you discover the appropriate metadata. You decide whether information should be an object tags or a label. When a tag adds information, you include it. Properties describe measurements and labels.</p>
 
-<p>To illustrate the thought process, let’s work through an example together. Imagine a sublime plugin that captures when a user writes a javascript 1self app like “Hello, 1self”. We’re going to step through the thinking required to create a representative, well-formed, robust and linkable event. If, post walkthrough, you’re still not sure, [please get in touch](mailto:team@1self.co]</p>
+<p>To illustrate the thought process, let’s work through an example together. Imagine a sublime plugin that captures when a user writes a javascript 1self app like “Hello, 1self”. We’re going to step through the thinking required to create a representative, well-formed, robust and linkable event. If, post walkthrough, you’re still not sure, [please get in touch](mailto:team@1self.co)</p>
 
 
 


### PR DESCRIPTION
The typo prevents the email address from being rendered as a link.
