### PR TITLE
Fix bug with having to click some cards twice

### DIFF
--- a/card-stack/card-stack.js
+++ b/card-stack/card-stack.js
@@ -228,8 +228,9 @@ $(function() {
             markCardUnique($('.stack li:last')[0], 'topOfMain');
 
             $cardList = $('.stack li');
+            var $stack = $('.stack');
 
-            $cardList.on('mousedown', function(e) {
+            $stack.on('mouseup', 'li', function(e) {
                 var id = '#' + this.id;
                 var idx = discardPile.indexOf(id);
                 if (idx > -1) {
@@ -238,7 +239,7 @@ $(function() {
                 }
             });
 
-            $('.nav-toggle').on('click', function(e) {
+            $stack.on('mouseup', '.nav-toggle', function(e) {
                 var $container = $(this).parents('.cardContainer');
                 $container.toggleClass('flip');
                 $container.siblings().toggleClass('flip');


### PR DESCRIPTION
Had to click some elements twice because of events being lost or not
recorded in the first place. Particularly this affected the show-more
button on cards.
